### PR TITLE
Use littlefs instead of spiffs

### DIFF
--- a/note-for-andy.md
+++ b/note-for-andy.md
@@ -1,3 +1,19 @@
+# improvement working on
+ - change SPIFFS to LittleFs
+ - can try SD card (maybe FAT)
+ - buzzer test
+ - everyone can accese the web page(?)
+ - check for first aid kit item(?)
+
+======================================
+# the below task is outdated
+ - button can not to change, just use toggle switch as they are not in used
+ - don't need to polt graph
+ - SD card connecting with ESP32-S3 have problem
+ - alarm function is waiting for buzzer and test only
+ - seems no ppl remember "everyone can accese the web page"
+
+======================================
 # task working on
  - WiFi
     - ~~soft wifi AP (use other device to connect WiFi)~~
@@ -21,12 +37,12 @@
     - use SPI & SD card to store the data
  - display on OLED
     - ~~LCD display sensor value~~
-    - use OLED to display sensor value
+    - ~~use OLED to display sensor value~~
     - display two graph: current & drop count(later)
 	  - INA219 (current sensor?)
-	  - the a, b, c of the square wave
+	  - ~~the a, b, c of the square wave~~
  - auto system
-    - calculate target drip rate
+    - ~~calculate target drip rate~~
     - ~~compare the drip rate~~
     - ~~add a field and the user input the drip he want~~
     - ~~auto move the motor~~
@@ -41,20 +57,21 @@
 
 ======================================
 # note for the code
- - wifi ssid:AutoConnectAP, password:password.
- - GPIO36 -> reading sensor data (Change in L40)
- - timer0 -> read sensor & time measure
- - timer1 -> auto control
- - timer2 -> control the motor
- - **don't use delay**
+ - wifi ssid:AutoConnectAP, password:password
+ - go to http://<IPAddress>/update for OTA update
+ - upload firmware.bin for main, spiffs.bin for SPIFFS files
+ - GPIO36 -> EXT interrupt for reading sensor data
+ - timer0 -> INT interrupt for read sensor & time measure
+ - timer1 -> INT interrupt for auto control
+ - timer3 -> INT interrupt for control the motor
 
 ======================================
 # learning/note
 - 4x4 keypad matrix
 - ~~use interrupt more (use phase change)~~
 - any GPIO can do SPI, dont use colored in gray
-- mostly will use 1*SPI, 1*UART, 1*I2C
-- printf()
+- mostly will use 1xSPI, 1xUART, 1xI2C
+- ~~printf()~~
 - soldering
 
 ======================================
@@ -353,6 +370,9 @@ OTA:
 
 ===========================
 # result for test_i2c
+ - the address of I2C can be found by the code provided in the example
+ - if there is no 2 things using the same, better not to change it
+
 ESP-ROM:esp32s3-20210327
 Build:Mar 27 2021
 rst:0x1 (POWERON),boot:0x8 (SPI_FAST_FLASH_BOOT)

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,6 +12,7 @@
 platform = espressif32
 board = esp32-s3-devkitc-1
 framework = arduino
+board_build.filesystem = littlefs	;as default filesystem is using SPIFFS
 upload_speed = 921600
 lib_deps = 
 	https://github.com/me-no-dev/ESPAsyncWebServer.git

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,10 +2,10 @@
   wifi ssid:AutoConnectAP, password:password.
   go to http://<IPAddress>/update for OTA update
   upload firmware.bin for main, spiffs.bin for SPIFFS files
-  GPIO36 -> reading sensor data (Change in L34)
-  timer0 -> read sensor & time measure
-  timer1 -> auto control
-  timer2 -> control the motor
+  GPIO36 -> EXT interrupt for reading sensor data
+  timer0 -> INT interrupt for read sensor & time measure
+  timer1 -> INT interrupt for auto control
+  timer3 -> INT interrupt for control the motor
 */
 
 #include <Arduino.h>
@@ -221,7 +221,6 @@ void writeFile(fs::FS &fs, const char *path, const char *message) {
 // create pointer for timer
 hw_timer_t *Timer0_cfg = NULL; // create a pointer for timer0
 hw_timer_t *Timer1_cfg = NULL; // create a pointer for timer1
-hw_timer_t *Timer2_cfg = NULL; // create a pointer for timer2
 hw_timer_t *Timer3_cfg = NULL; // create a pointer for timer3
 
 // EXT interrupt to pin 36, for sensor detected drops and measure the time


### PR DESCRIPTION
# The main reason of not using SPIFFS is, SPIFFS may be removed in the future.

LittleFs and SPIFFS
 - share compatible 
 - but incompatible on flash implementations
so is better to use one only

Limitations of SPIFFS:
 - limited by the RAM
 - designed for small system originally
 - filename should not more than 32(31) chars

Note on LIttleFs
 - Mostly, just change all "SPIFFS" to "LittleFS" in the code, then it works
 - opening files in subdirectory requires specifying the complete path
 - e.g. "/sub/dir/file.txt"
 - subdirectory can automatically be created when a file create
 - and will auto delete when the last file is deleted
 - the filesystem default is using SPIFFS, so need to change in .ini
 - OTA upload's filename is littlefs.bin